### PR TITLE
docs: record web as a target, and the icon and token decisions it forces

### DIFF
--- a/docs/adr/0003-style-with-stylesheet-and-a-tokens-module.md
+++ b/docs/adr/0003-style-with-stylesheet-and-a-tokens-module.md
@@ -10,3 +10,9 @@
 ## Consequences
 
 Porting a Legacy App screen means rewriting its class strings rather than copying them, so each screen costs more than a faithful port would. The tokens module is a foundation, not a screen's incidental output: it lands on the rewrite's base branch before any screen issue starts. Dark mode is expressed once in the tokens rather than as per-screen conditionals.
+
+## Amendment — universal `@expo/ui` only (ADR-0004)
+
+ADR-0004 made web a target, which narrows this decision: shared code may use only the **universal** `@expo/ui` namespace, imported from the package root. Those components delegate to SwiftUI on iOS and Jetpack Compose on Android, and fall back to `react-dom` or `react-native-web` implementations on web. The platform-specific `@expo/ui/swift-ui` and `@expo/ui/jetpack-compose` namespaces do not run on web at all, so reaching for either commits you to writing the `.web.tsx` counterpart as well.
+
+The universal set is not a complete substitute — `Icon` in particular has no web implementation, which is why ADR-0005 does not use it. Treat "is this component universal?" as the first question when building a screen, not something discovered when the web build breaks.

--- a/docs/adr/0004-support-web-as-a-target.md
+++ b/docs/adr/0004-support-web-as-a-target.md
@@ -1,0 +1,18 @@
+# Support web as a target
+
+The rewrite ships iOS, Android **and** web. `app.json` already sets `web.output: "static"`, and that is a supported target rather than leftover scaffolding: the app should be reachable from a browser, not only from a store install. The native-first direction of ADR-0002 is unchanged — screens are still built on `@expo/ui` and native primitives — but every screen must also render on web, and the parts of the SDK that are native-only now need a deliberate web answer instead of an omission.
+
+## Considered options
+
+- **Native only** — drop `react-dom` and `react-native-web`, delete `web.output` and the web tab layout. Much the cheapest option, and it removes three constraints at once: all three `@expo/ui` namespaces become available, `expo-secure-store` covers token storage with no per-platform split, and no screen carries a responsive-layout obligation. Rejected because it puts the app behind a store install for a community that is largely on laptops during the day.
+- **Take the `NativeTabs` web fallback** — Expo renders native tabs on web as "a basic implementation, loosely based on iPad design". Nothing to write, and web keeps working as tabs are added. Rejected because a bottom tab bar is the wrong shape in a desktop browser, and the fallback's appearance is neither documented nor ours to control.
+
+## Consequences
+
+Only the **universal** `@expo/ui` namespace is available to shared code — `@expo/ui/swift-ui` and `@expo/ui/jetpack-compose` do not run on web, which amends ADR-0003. Reaching for either means writing a `.web.tsx` alongside it.
+
+Native-only modules need a per-platform answer rather than a reinstall. `expo-secure-store` is Android and iOS only, which is what ADR-0006 resolves. `@expo/ui`'s universal `Icon` does not render on web, which is what ADR-0005 resolves. `expo-glass-effect`, already a dependency, is iOS and tvOS only.
+
+The tab trigger list now exists twice — `application-tabs.native.tsx` for native, `application-tabs.tsx` for web using the headless `Tabs`, `TabSlot`, `TabList` and `TabTrigger` from `expo-router/ui`. The two must stay in sync as tabs are added; there is no shared source for them. This split is Expo's own recommended structure for this case, so the duplication is expected rather than a smell.
+
+Every screen issue under #170 carries a web layout obligation. Feature parity now means parity on three platforms, and a screen is not done when it only works on a phone.

--- a/docs/adr/0005-one-icon-set-with-a-tab-bar-exception.md
+++ b/docs/adr/0005-one-icon-set-with-a-tab-bar-exception.md
@@ -1,0 +1,20 @@
+# One icon set, with a tab bar exception
+
+Icons come from `@react-native-vector-icons/material-design-icons` everywhere — inside screens and in the web tab bar — with one icon name per site, rendering on all three platforms. The single exception is the five native tab triggers, which keep their `sf` prop alongside `src`, because `NativeTabs.Trigger.Icon` performs the platform switch itself and SF Symbols cost nothing there.
+
+Native icons on each platform means two icon sets by definition: SF Symbols exists only on Apple platforms, Material Symbols is Google's. There is no name that renders as a real SF Symbol on iOS and a real Material Symbol on Android. Choosing one set is choosing to spend that nativeness once, in the tab bar, rather than everywhere.
+
+## Considered options
+
+- **Per-platform icons app-wide, via `@expo/ui`'s universal `Icon`** — the most native option on iOS, and the direction `Icon.select({ ios, android })` is designed for. Rejected on two counts. `Icon` does not render on web: its own docs say so, and the package ships `index.tsx`, `index.ios.tsx` and `index.android.tsx` with no web file, so a web target would need a shim for the app's most-used primitive. And the Legacy App used 45 distinct icons, each of which would need an SF Symbol name *and* a Material Symbols name chosen by hand — several with no counterpart worth defending (`Nfc` for the **Card**, `Utensils` for the **Menu**, `Megaphone`, `LibraryBig`).
+- **One SVG set — `lucide-react-native` with `react-native-svg`** — the Legacy App's approach. One name, identical rendering on all three platforms, colour straight from the tokens module, and the 45 existing icon names port over unchanged. Rejected because it re-adds two dependencies the rewrite dropped and is non-native on both iOS and Android, which is the opposite of ADR-0002's direction.
+
+## Consequences
+
+iOS screens show Material iconography beside SwiftUI controls rendered by `@expo/ui`. This is accepted deliberately: the tab bar is where Apple's conventions are strongest and most noticed, and it is the one place the native set survives.
+
+`getImageSourceSync` requires a development build, so icons will not render in Expo Go. `@react-native-vector-icons/material-design-icons` is already a dependency and already registered as a config plugin in `app.json`.
+
+Two fixes fall out of this in `application-tabs.native.tsx`. The calendar trigger uses `md="calendar_today"`, and the built-in `md` prop renders only outlined Material Symbols — so unlike the other four tabs it cannot do the outlined-to-filled swap on selection. It should move to `src` with `getImageSourceSync`, like its siblings. Separately, `getImageSourceSync(..., "black")` bakes the colour in at module load; this is Expo's own documented pattern and only affects Android, since `sf` takes precedence on iOS, but it needs checking against dark mode on an Android device.
+
+Icon colour in screens comes from the tokens module of ADR-0003, not from per-call literals.

--- a/docs/adr/0006-store-the-session-token-per-platform.md
+++ b/docs/adr/0006-store-the-session-token-per-platform.md
@@ -1,0 +1,20 @@
+# Store the session token per platform
+
+One session-store module, two implementations selected by platform extension. On native it wraps `expo-secure-store`, which keeps the token in the iOS Keychain or in Android's Keystore-encrypted `SharedPreferences`. On web it wraps `localStorage`. Callers import one module and never branch on platform.
+
+This is forced by ADR-0004: `expo-secure-store` supports Android, iOS and tvOS only, and `isAvailableAsync()` resolves `true` on Android and iOS alone. Web has no equivalent, so the choice is not *which* secure store but what to accept in its absence.
+
+## Considered options
+
+- **In-memory only on web** — the token never reaches disk in the browser, so there is nothing in storage for an XSS to exfiltrate. Rejected because the session would not survive a refresh, a new tab, or a restored browser session. For a campus app people open between lectures, that is a login every time.
+- **An httpOnly cookie issued by the its-tps API** — the only option that is genuinely secure on web, since JavaScript cannot read the token at all. Rejected because `CONTEXT.md` records the its-tps API as fixed and the source of truth; adding a cookie-session mode and the matching CORS credentials config is not this repo's to make. Worth reopening if the API ever gains one.
+
+## Consequences
+
+**Web security is weaker than native, and this ADR says so rather than implying parity.** Any cross-site scripting flaw in the web build can read the session token out of `localStorage`. Native keeps hardware-backed storage. Nothing beyond the session token goes through this module — it is not a general-purpose store, and adding a second secret to it is a decision to revisit, not a detail.
+
+`expo-secure-store` must be reinstalled and added to `app.json`'s plugin list. For App Store submission, set `ios.config.usesNonExemptEncryption` to `false`; the Legacy App carried the equivalent as `ITSAppUsesNonExemptEncryption` in its `infoPlist`.
+
+`SecureStore` values persist across uninstall on iOS but not on Android. Sign-out must delete the token explicitly rather than relying on the app being removed.
+
+This unblocks the auth work in #170 — session, route guards and the `isLoggedIn = false` currently hardcoded in `src/app/_layout.tsx` — but does not decide where session *state* lives at runtime. Whether that is React Query, context, or a store remains open, and is tangled with whether `zustand` returns at all.


### PR DESCRIPTION
Foundations PR against the rewrite's base branch, per the foundations rule in #170: cross-cutting work lands on the base by its own small PR rather than inside a feature branch.

Docs only — no code changes.

## What this settles

A grilling session walked the decisions still deferred in #170. Five came out of it; three needed an ADR and one needed an existing ADR narrowed.

| | |
|---|---|
| **ADR-0004** | Web is a supported target alongside iOS and Android — `app.json` already sets `web.output: "static"`, and that is now deliberate |
| **ADR-0005** | One Material Design Icons set everywhere, with `sf` kept only in the five native tab triggers |
| **ADR-0006** | Session token storage splits per platform: `expo-secure-store` on native, `localStorage` on web |
| **ADR-0003** | Amended — only the universal `@expo/ui` namespace is available to shared code |

## Why the amendment to 0003

`@expo/ui/swift-ui` and `@expo/ui/jetpack-compose` have no web implementation. ADR-0003 committed the whole styling layer to `@expo/ui` without noting a platform boundary, because it was written for a native-only app and nothing in it said so. The amendment makes "is this component universal?" the first question when building a screen, rather than something discovered when the web build breaks.

## Why 0005 does not use `@expo/ui`'s `Icon`

Two reasons, both checked rather than assumed:

- Its docs carry the note *"`Icon` does not render on web"*, and the package ships `index.tsx`, `index.ios.tsx` and `index.android.tsx` with no web file.
- The Legacy App used 45 distinct icons. Going per-platform means hand-picking an SF Symbol name *and* a Material Symbols name for each, and several have no counterpart worth defending — `Nfc` for the **Card**, `Utensils` for the **Menu**, `Megaphone`, `LibraryBig`.

Native icons on each platform means two sets by definition. This spends that nativeness once, in the tab bar, where Apple's conventions are strongest.

## Follow-ups noted, not fixed here

Both belong to #179 rather than this PR:

- `application-tabs.tsx` renders a bare `<Tabs />` from `expo-router/ui`, with no `TabSlot` or `TabList` — so the web tab bar currently shows nothing.
- In `application-tabs.native.tsx`, the calendar trigger uses `md="calendar_today"`. The built-in `md` prop renders only outlined Material Symbols, so unlike the other four tabs it cannot swap to a filled icon on selection. It should move to `src` with `getImageSourceSync`.

## Review notes

- The rationale in ADR-0004 for *why* web is worth supporting is my inference from the decision, not something stated in the session. Worth rewriting if the real reason differs — that sentence is what a future maintainer will weigh when reopening it.
- ADR-0005's claim that the MDI font renders under `react-native-web` follows from the library's design; it has not been confirmed against a web build.

Refs #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
